### PR TITLE
Handle delayed metadata

### DIFF
--- a/toolbar/toolbar.js
+++ b/toolbar/toolbar.js
@@ -12,12 +12,19 @@ export default class Toolbar
 		this.path = payload.path || '/__clockwork/'
 	}
 
-	show() {
+	show(attempts = 0) {
 		if (! this.enabled) return
+		if (attempts > 3) return
 
 		fetch(`${this.path}${this.requestId}`)
 			.then(request => request.json())
-			.then(request => this.render(new Request(request)))
+			.then(request => {
+				if (! Object.keys(request).length) {
+					return setTimeout(() => this.show(attempts + 1), (attempts + 1) * (attempts + 1) * 100)
+				}
+
+				this.render(new Request(request))
+			})
 	}
 
 	render(request) {


### PR DESCRIPTION
- toolbar - loading of the request metadata is now retried 3 times after 100, 400 and 900 ms to support delayed recording (itsgoingd/clockwork#426)